### PR TITLE
fix(plerkle): improve metric aggregation

### DIFF
--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -665,8 +665,7 @@ impl GeyserPlugin for Plerkle<'static> {
         }
 
         metric! {
-            let slt_idx = format!("{}-{}", slot, transaction_info.index);
-            statsd_count!("transaction_seen_event", 1, "slot-idx" => &slt_idx);
+            statsd_count!("transaction_seen_event", 1);
         }
         Ok(())
     }


### PR DESCRIPTION
The statsd daemon will aggregate metrics to reduce cost. Aggregation is poor when a dimension is repeatedly changing (e.g slot-idx). This fixes it.